### PR TITLE
Add thumbnail module to account for ROI and/or sample shift

### DIFF
--- a/ashlar/reg.py
+++ b/ashlar/reg.py
@@ -764,7 +764,8 @@ class LayerAligner(object):
     def constrain_positions(self):
         # Computed shifts of exactly 0,0 seem to result from failed
         # registration. We need to throw those out for this purpose.
-        discard = (self.shifts == 0).all(axis=1)
+        cycle_offset = getattr(self, 'cycle_offset', np.array([0.0, 0.0]))
+        discard = (self.shifts == cycle_offset).all(axis=1)
         # Take the median of registered shifts to determine the offset
         # (translation) from the reference image to this one.
         offset = np.nan_to_num(np.median(self.shifts[~discard], axis=0))

--- a/ashlar/reg.py
+++ b/ashlar/reg.py
@@ -710,7 +710,7 @@ class EdgeAligner(object):
 
 class LayerAligner(object):
 
-    def __init__(self, reader, reference_aligner, channel=None, max_shift=27,
+    def __init__(self, reader, reference_aligner, channel=None, max_shift=15,
                  verbose=False):
         self.reader = reader
         self.reference_aligner = reference_aligner

--- a/ashlar/reg.py
+++ b/ashlar/reg.py
@@ -710,7 +710,7 @@ class EdgeAligner(object):
 
 class LayerAligner(object):
 
-    def __init__(self, reader, reference_aligner, channel=None, max_shift=15,
+    def __init__(self, reader, reference_aligner, channel=None, max_shift=27,
                  verbose=False):
         self.reader = reader
         self.reference_aligner = reference_aligner
@@ -755,8 +755,9 @@ class LayerAligner(object):
 
     def calculate_positions(self):
         self.positions = (
-            self.reference_aligner.positions[self.reference_idx] + self.shifts
-        )
+            self.reference_aligner.positions - 
+            self.reference_aligner.metadata.positions
+        )[self.reference_idx] + self.tile_positions + self.shifts
         self.constrain_positions()
         self.centers = self.positions + self.metadata.size / 2
 

--- a/ashlar/reg.py
+++ b/ashlar/reg.py
@@ -785,6 +785,8 @@ class LayerAligner(object):
     def register(self, t):
         """Return relative shift between images and the alignment error."""
         its, ref_img, img = self.overlap(t)
+        if np.any(np.array(its.shape) == 0): 
+            return (0, 0), np.inf 
         ref_img_f = fft2(whiten(ref_img))
         img_f = fft2(whiten(img))
         shift, error, _ = skimage.feature.register_translation(
@@ -1215,6 +1217,8 @@ def paste(target, img, pos, func=None):
     x2 = None if pos_f[1] >= 0 else -1
     img = img[y1:y2, x1:x2]
     target_slice = target_slice[y1:y2, x1:x2]
+    if np.any(np.array(target_slice.shape) == 0): 
+        return 
     if np.issubdtype(img.dtype, np.floating):
         np.clip(img, 0, 1, img)
     img = skimage.util.dtype.convert(img, target.dtype)

--- a/ashlar/reg.py
+++ b/ashlar/reg.py
@@ -857,7 +857,7 @@ class Intersection(object):
         max_shape = (corners2 - corners1).max(axis=0)
         min_size = min_size.clip(1, max_shape)
         position = corners1.max(axis=0)
-        initial_shape = np.ceil(corners2.min(axis=0) - position).astype(int)
+        initial_shape = np.floor(corners2.min(axis=0) - position).astype(int)
         clipped_shape = np.maximum(initial_shape, min_size)
         self.shape = np.ceil(clipped_shape).astype(int)
         self.padding = self.shape - initial_shape

--- a/ashlar/scripts/ashlar.py
+++ b/ashlar/scripts/ashlar.py
@@ -197,10 +197,6 @@ def process_single(
             print('    reading %s' % filepath)
         reader = reg.BioformatsReader(filepath, plate=plate, well=well)
         reader.metadata.positions
-        reader.metadata._positions += [0, 1198]
-        if 'VIMENTIN' in filepath:
-            print('account for cycle8')
-            reader.metadata._positions += [0, -868]
         layer_aligner = reg.LayerAligner(reader, edge_aligner, **aligner_args)
         layer_aligner.run()
         mosaic_args_final = mosaic_args.copy()

--- a/ashlar/scripts/ashlar.py
+++ b/ashlar/scripts/ashlar.py
@@ -196,6 +196,11 @@ def process_single(
             print('Cycle %d:' % cycle)
             print('    reading %s' % filepath)
         reader = reg.BioformatsReader(filepath, plate=plate, well=well)
+        reader.metadata.positions
+        reader.metadata._positions += [0, 1198]
+        if 'VIMENTIN' in filepath:
+            print('account for cycle8')
+            reader.metadata._positions += [0, -868]
         layer_aligner = reg.LayerAligner(reader, edge_aligner, **aligner_args)
         layer_aligner.run()
         mosaic_args_final = mosaic_args.copy()

--- a/ashlar/scripts/ashlar.py
+++ b/ashlar/scripts/ashlar.py
@@ -7,6 +7,7 @@ except ImportError:
     import pathlib2 as pathlib
 from .. import __version__ as VERSION
 from .. import reg
+from .. import thumbnail
 
 
 def main(argv=sys.argv):
@@ -196,7 +197,11 @@ def process_single(
             print('Cycle %d:' % cycle)
             print('    reading %s' % filepath)
         reader = reg.BioformatsReader(filepath, plate=plate, well=well)
+        cycle_offset = thumbnail.calculate_cycle_offset(
+            reg.BioformatsReader(filepaths[0], plate=plate, well=well), reader
+        )
         reader.metadata.positions
+        reader.metadata._positions += cycle_offset
         layer_aligner = reg.LayerAligner(reader, edge_aligner, **aligner_args)
         layer_aligner.run()
         mosaic_args_final = mosaic_args.copy()

--- a/ashlar/scripts/ashlar.py
+++ b/ashlar/scripts/ashlar.py
@@ -192,13 +192,19 @@ def process_single(
     mosaic.run()
     num_channels += len(mosaic.channels)
 
+    reader.thumbnail_img = thumbnail.thumbnail(
+        reader, channel=aligner_args['channel']
+    )
+    ref_reader = reader
+
     for cycle, filepath in enumerate(filepaths[1:], 1):
         if not quiet:
             print('Cycle %d:' % cycle)
             print('    reading %s' % filepath)
         reader = reg.BioformatsReader(filepath, plate=plate, well=well)
         cycle_offset = thumbnail.calculate_cycle_offset(
-            reg.BioformatsReader(filepaths[0], plate=plate, well=well), reader
+            ref_reader, reader,
+            channel=aligner_args['channel'], save=(False, True)
         )
         reader.metadata.positions
         reader.metadata._positions += cycle_offset

--- a/ashlar/scripts/ashlar.py
+++ b/ashlar/scripts/ashlar.py
@@ -209,6 +209,7 @@ def process_single(
         reader.metadata.positions
         reader.metadata._positions += cycle_offset
         layer_aligner = reg.LayerAligner(reader, edge_aligner, **aligner_args)
+        layer_aligner.cycle_offset = -1.0 * cycle_offset
         layer_aligner.run()
         mosaic_args_final = mosaic_args.copy()
         if ffp_paths:

--- a/ashlar/thumbnail.py
+++ b/ashlar/thumbnail.py
@@ -1,9 +1,14 @@
 from __future__ import print_function, division
 import sys
+try:
+    import pathlib
+except ImportError:
+    import pathlib2 as pathlib
 import numpy as np
 from . import reg
 from skimage.transform import rescale
 from skimage.feature import register_translation
+from skimage.io import imsave
 
 
 def make_thumbnail(reader, channel=0, scale=0.05):
@@ -16,7 +21,7 @@ def make_thumbnail(reader, channel=0, scale=0.05):
 
     total = reader.metadata.num_images
     for i in range(total):
-        sys.stdout.write("\rLoading %d/%d" % (i + 1, total))
+        sys.stdout.write("\r        Loading %d/%d" % (i + 1, total))
         sys.stdout.flush()
         reg.paste(
             mosaic, rescale(reader.read(c=channel, series=i), scale), positions[i] * scale, np.maximum
@@ -24,6 +29,7 @@ def make_thumbnail(reader, channel=0, scale=0.05):
     print()
 
     return mosaic
+
 
 def calculate_image_offset(img1, img2, upsample_factor=1):
 
@@ -34,18 +40,49 @@ def calculate_image_offset(img1, img2, upsample_factor=1):
 
     return shift
 
-def calculate_cycle_offset(reader1, reader2, channel=0, scale=0.05):
+
+def calculate_cycle_offset(reader1, reader2, channel=0, scale=0.05, save=(False, False)):
     
-    img1 = make_thumbnail(reader1, channel=channel, scale=scale)
+    img1 = reader1.thumbnail_img \
+        if hasattr (reader1, 'thumbnail_img') \
+        else make_thumbnail(reader1, channel=channel, scale=scale)
     img2 = make_thumbnail(reader2, channel=channel, scale=scale)
+    reader1.thumbnail_img = img1
+
+    for file_path, img in zip(
+        [reader1.path, reader2.path],
+        [img1*save[0], img2*save[1]]
+    ):
+        if img.any(): _save_as_tif(img, file_path, post_fix='-thumbnail')
 
     img_offset = calculate_image_offset(img1, img2, int(1/scale)) * 1/scale
     ori_diff = reader2.metadata.origin - reader1.metadata.origin
 
     print(
-        'Estimated offset [ y, x] =',
+        '\r        Estimated offset [y x] =',
         img_offset - ori_diff
     )
 
     return img_offset - ori_diff
 
+
+def thumbnail(reader, post_fix='-thumbnail', channel=0, scale=0.05):
+
+    img = make_thumbnail(reader, channel, scale)
+    _save_as_tif(img, reader.path, post_fix)
+    
+    return img
+    
+
+def _save_as_tif(img, file_path, post_fix=''):
+    
+    input_path = pathlib.Path(file_path)
+
+    if input_path.is_dir():
+        raise RuntimeError("file_path musts point to a file not a directory")
+
+    filename = input_path.name.replace('.', post_fix + '.', 1)
+    out_path = input_path.parent / filename
+    out_path = out_path.with_suffix('').with_suffix('.tif')
+
+    imsave(out_path, img)

--- a/ashlar/thumbnail.py
+++ b/ashlar/thumbnail.py
@@ -1,0 +1,52 @@
+from __future__ import print_function, division
+import sys
+import numpy as np
+import matplotlib.pyplot as plt
+# import matplotlib.patches as mpatches
+from . import reg
+from skimage.transform import rescale
+from skimage.feature import register_translation
+
+
+def make_thumbnail(reader, channel=0, scale=0.05, plot=False, save_thumbnail=False):
+    
+    metadata = reader.metadata
+
+    positions = metadata.positions - metadata.origin
+    mshape = (((positions + metadata.size).max(axis=0) + 1) * scale).astype(int)
+    mosaic = np.zeros(mshape, dtype=np.uint16)
+
+    total = reader.metadata.num_images
+    for i in range(total):
+        sys.stdout.write("\rLoading %d/%d" % (i + 1, total))
+        sys.stdout.flush()
+        reg.paste(
+            mosaic, rescale(reader.read(c=channel, series=i), scale), positions[i] * scale, np.maximum
+        )
+    print()
+
+    return mosaic
+
+def calculate_image_offset(img1, img2):
+
+    ref = reg.fft2(reg.whiten(img1))
+    test = reg.fft2(reg.whiten(img2))
+
+    shift, error, _ = register_translation(ref, test, 1, 'fourier')
+
+    return shift
+
+def calculate_cycle_offset(reader1, reader2, channel=0, scale=0.05):
+    
+    img1 = make_thumbnail(reader1, channel=channel, scale=scale)
+    img2 = make_thumbnail(reader2, channel=channel, scale=scale)
+
+    img_offset = calculate_image_offset(img1, img2) * 1/scale
+
+    ori_diff = reader2.metadata.origin - reader1.metadata.origin
+
+    return img_offset - ori_diff
+
+
+if __name__ == '__main__':
+    main()

--- a/ashlar/thumbnail.py
+++ b/ashlar/thumbnail.py
@@ -1,19 +1,17 @@
 from __future__ import print_function, division
 import sys
 import numpy as np
-import matplotlib.pyplot as plt
-# import matplotlib.patches as mpatches
 from . import reg
 from skimage.transform import rescale
 from skimage.feature import register_translation
 
 
-def make_thumbnail(reader, channel=0, scale=0.05, plot=False, save_thumbnail=False):
+def make_thumbnail(reader, channel=0, scale=0.05):
     
     metadata = reader.metadata
-
     positions = metadata.positions - metadata.origin
-    mshape = (((positions + metadata.size).max(axis=0) + 1) * scale).astype(int)
+    coordinate_max = (positions + metadata.size).max(axis=0) 
+    mshape = ((coordinate_max+ 1) * scale).astype(int)
     mosaic = np.zeros(mshape, dtype=np.uint16)
 
     total = reader.metadata.num_images
@@ -27,12 +25,12 @@ def make_thumbnail(reader, channel=0, scale=0.05, plot=False, save_thumbnail=Fal
 
     return mosaic
 
-def calculate_image_offset(img1, img2):
+def calculate_image_offset(img1, img2, upsample_factor=1):
 
     ref = reg.fft2(reg.whiten(img1))
     test = reg.fft2(reg.whiten(img2))
 
-    shift, error, _ = register_translation(ref, test, 1, 'fourier')
+    shift, error, _ = register_translation(ref, test, upsample_factor, 'fourier')
 
     return shift
 
@@ -41,12 +39,13 @@ def calculate_cycle_offset(reader1, reader2, channel=0, scale=0.05):
     img1 = make_thumbnail(reader1, channel=channel, scale=scale)
     img2 = make_thumbnail(reader2, channel=channel, scale=scale)
 
-    img_offset = calculate_image_offset(img1, img2) * 1/scale
-
+    img_offset = calculate_image_offset(img1, img2, int(1/scale)) * 1/scale
     ori_diff = reader2.metadata.origin - reader1.metadata.origin
+
+    print(
+        'Estimated offset [ y, x] =',
+        img_offset - ori_diff
+    )
 
     return img_offset - ori_diff
 
-
-if __name__ == '__main__':
-    main()


### PR DESCRIPTION
`reg.py`
1. @@ -695,68 +695,69 @@, during tile-to-tile registration, tiles from two cycles may not have the same nominal position
1. @@ -784,6 +785,8 @@, @@ -1214,6 +1217,8 @@, handle no overlapping tiles from two cycles


`ashlar.py`
1. @@ -191,11 +192,22 @@, generate reference thumbnail after edge alignment, for layer alignment, generate thumbnail and calculate offset with the reference thumbnail. The offset is used to correct nominal positions through the back door. 


