### PR TITLE
Fix load illumination profiles

### DIFF
--- a/ashlar/reg.py
+++ b/ashlar/reg.py
@@ -871,9 +871,11 @@ class Mosaic(object):
         assert profile_type in ('dark', 'flat'), "profile_type must be either 'dark' or 'flat'."
         if path is None:
             profile_shape = (num_channels, 1, 1)
-            return np.zeros(profile_shape) \
-                if profile_type is 'dark' \
-                else np.ones(profile_shape)
+            return (
+                np.zeros(profile_shape) 
+                    if profile_type is 'dark' 
+                    else np.ones(profile_shape)
+            )
 
         expected_ndim = 2 if num_channels is 1 else 3
         profile = skimage.io.imread(path)
@@ -885,6 +887,9 @@ class Mosaic(object):
             )
 
         profile = np.atleast_3d(profile)
+        # skimage.io.imread convert images with 3 and 4 channels into (Y, X, C) shape, 
+        # but as (C, Y, X) for images with other channel numbers. We normalize 
+        # image-shape to (C, Y, X) discarding number of channels in the image.
         if num_channels in (1, 3, 4):
             profile = np.moveaxis(profile, 2, 0)
         if profile.shape != (num_channels,) + img_size:

--- a/ashlar/reg.py
+++ b/ashlar/reg.py
@@ -857,11 +857,10 @@ class Mosaic(object):
                 skimage.io.imread(dfp_path) if dfp_path else np.zeros((1, 1, c))
             )
             self.ffp = np.atleast_3d(
-                skimage.io.imread(ffp_path) if ffp_path else np.zeros((1, 1, c))
+                skimage.io.imread(ffp_path) if ffp_path else np.ones((1, 1, c))
             )
             # FIXME This assumes integer dtypes. Do we need to support floats?
-            if np.issubdtype(self.dfp.dtype, np.integer):
-                self.dfp /= np.iinfo(self.dtype).max
+            self.dfp /= np.iinfo(self.dtype).max
             try:
                 self.dfp = np.moveaxis(self.dfp, self.dfp.shape.index(c), -1)
                 self.ffp = np.moveaxis(self.ffp, self.ffp.shape.index(c), -1)

--- a/ashlar/reg.py
+++ b/ashlar/reg.py
@@ -851,10 +851,10 @@ class Mosaic(object):
         if dfp_path or ffp_path:
             c = max(self.channels) + 1
             self.dfp = np.atleast_3d(
-                skimage.io.imread(dfp_path) if dfp_path else np.zeros(c)
+                skimage.io.imread(dfp_path) if dfp_path else np.zeros((1, 1, c))
             )
             self.ffp = np.atleast_3d(
-                skimage.io.imread(ffp_path) if ffp_path else np.ones(c)
+                skimage.io.imread(ffp_path) if ffp_path else np.zeros((1, 1, c))
             )
             # FIXME This assumes integer dtypes. Do we need to support floats?
             self.dfp /= np.iinfo(self.dtype).max

--- a/ashlar/reg.py
+++ b/ashlar/reg.py
@@ -889,7 +889,7 @@ class Mosaic(object):
         profile = np.atleast_3d(profile)
         # skimage.io.imread convert images with 3 and 4 channels into (Y, X, C) shape, 
         # but as (C, Y, X) for images with other channel numbers. We normalize 
-        # image-shape to (C, Y, X) discarding number of channels in the image.
+        # image-shape to (C, Y, X) regardless of the number of channels in the image.
         if num_channels in (1, 3, 4):
             profile = np.moveaxis(profile, 2, 0)
         if profile.shape != (num_channels,) + img_size:

--- a/ashlar/reg.py
+++ b/ashlar/reg.py
@@ -856,6 +856,9 @@ class Mosaic(object):
             self.ffp = np.atleast_3d(
                 skimage.io.imread(ffp_path) if ffp_path else np.zeros((1, 1, c))
             )
+            if c is not 1:
+                self.dfp = np.moveaxis(self.dfp, self.dfp.shape.index(c), -1)
+                self.ffp = np.moveaxis(self.ffp, self.ffp.shape.index(c), -1)
             # FIXME This assumes integer dtypes. Do we need to support floats?
             self.dfp /= np.iinfo(self.dtype).max
             self.do_correction = True


### PR DESCRIPTION
The fixes include
- Handle illumination images more than 4 channels
- When the `--output-channels` arg is set, the correct channel in the illumination profiles is used

(Sorry for the messy commits, please squash them when merging)