### PR TITLE
Drop Python 2 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:19.10
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y \
@@ -10,19 +10,19 @@ RUN apt-get update \
         libfftw3-long3 \
         libfftw3-single3 \
         openjdk-8-jdk-headless \
-        python-dev \
-        python-pip \
-        python-tk \
+        python3-dev \
+        python3-pip \
+        python3-tk \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install -q -U \
+RUN pip3 install -q -U \
     cython \
     numpy \
     pip \
     scipy
 
 COPY / /app/ashlar/
-RUN pip install /app/ashlar
+RUN pip3 install /app/ashlar
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 ENV OMP_NUM_THREADS 1

--- a/ashlar/filepattern.py
+++ b/ashlar/filepattern.py
@@ -1,8 +1,5 @@
 import re
-try:
-    import pathlib
-except ImportError:
-    import pathlib2 as pathlib
+import pathlib
 import numpy as np
 import skimage.io
 from . import reg

--- a/ashlar/fileseries.py
+++ b/ashlar/fileseries.py
@@ -1,9 +1,6 @@
 import re
 import itertools
-try:
-    import pathlib
-except ImportError:
-    import pathlib2 as pathlib
+import pathlib
 import numpy as np
 import skimage.io
 from . import reg

--- a/ashlar/reg.py
+++ b/ashlar/reg.py
@@ -548,16 +548,18 @@ class EdgeAligner(object):
         )
         spanning_tree = nx.Graph()
         spanning_tree.add_nodes_from(g)
-        for cc in nx.connected_component_subgraphs(g):
+        for c in nx.connected_components(g):
+            cc = g.subgraph(c)
             center = nx.center(cc)[0]
             paths = nx.single_source_dijkstra_path(cc, center).values()
             for path in paths:
-                spanning_tree.add_path(path)
+                nx.add_path(spanning_tree, path)
         self.spanning_tree = spanning_tree
 
     def calculate_positions(self):
         shifts = {}
-        for cc in nx.connected_component_subgraphs(self.spanning_tree):
+        for c in nx.connected_components(self.spanning_tree):
+            cc = self.spanning_tree.subgraph(c)
             center = nx.center(cc)[0]
             shifts[center] = np.array([0, 0])
             for edge in nx.traversal.bfs_edges(cc, center):
@@ -575,7 +577,7 @@ class EdgeAligner(object):
 
     def fit_model(self):
         components = sorted(
-            nx.connected_component_subgraphs(self.spanning_tree),
+            nx.connected_components(self.spanning_tree),
             key=len, reverse=True
         )
         # Fit LR model on positions of largest connected component.

--- a/ashlar/reg.py
+++ b/ashlar/reg.py
@@ -7,10 +7,7 @@ import xml.etree.ElementTree
 import io
 import uuid
 import struct
-try:
-    import pathlib
-except ImportError:
-    import pathlib2 as pathlib
+import pathlib
 import jnius_config
 import numpy as np
 import scipy.ndimage

--- a/ashlar/scripts/ashlar.py
+++ b/ashlar/scripts/ashlar.py
@@ -2,10 +2,7 @@ from __future__ import print_function
 import sys
 import re
 import argparse
-try:
-    import pathlib
-except ImportError:
-    import pathlib2 as pathlib
+import pathlib
 from .. import __version__ as VERSION
 from .. import reg
 from ..reg import PlateReader, BioformatsReader

--- a/ashlar/scripts/ashlar.py
+++ b/ashlar/scripts/ashlar.py
@@ -16,12 +16,6 @@ from ..zen import ZenReader
 
 def main(argv=sys.argv):
 
-    if sys.version_info.major < 3:
-        print("===========================================================")
-        print("** NOTICE: Python 2 support will end on January 1, 2020. **")
-        print("===========================================================")
-        print()
-
     parser = argparse.ArgumentParser(
         description='Stitch and align one or more multi-series images'
     )

--- a/ashlar/thumbnail.py
+++ b/ashlar/thumbnail.py
@@ -1,9 +1,6 @@
 from __future__ import print_function, division
 import sys
-try:
-    import pathlib
-except ImportError:
-    import pathlib2 as pathlib
+import pathlib
 import numpy as np
 from . import utils
 from skimage.transform import rescale

--- a/ashlar/zen.py
+++ b/ashlar/zen.py
@@ -1,11 +1,5 @@
-try:
-    import pathlib
-except ImportError:
-    import pathlib2 as pathlib
-try:
-    from urllib.parse import unquote as urllib_unquote
-except ImportError:
-    from urllib import unquote as urllib_unquote
+import pathlib
+from urllib.parse import unquote as urllib_unquote
 import xml.etree.ElementTree
 import numpy as np
 import skimage.io

--- a/setup.py
+++ b/setup.py
@@ -12,16 +12,15 @@ from setuptools.command.build_py import build_py
 import versioneer
 
 requires = [
-    'numpy>=1.13.0',
-    'future>=0.16.0',
-    'cython>=0.27.3',
+    'numpy>=1.18.1',
+    'cython>=0.29.14',
     'pyjnius==1.2.0',
-    'matplotlib>=2.1.0',
-    'networkx>=2.0',
+    'matplotlib>=3.1.2',
+    'networkx>=2.4',
     'pyfftw>=0.10.4',
-    'scipy>=0.19.1',
-    'scikit-image>=0.14.0',
-    'scikit-learn>=0.19.1'
+    'scipy>=1.3,<1.4', # Until pyfftw updated for scipy 1.4 fft API change
+    'scikit-image>=0.16.2',
+    'scikit-learn>=0.21.1'
 ]
 
 
@@ -108,9 +107,6 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=requires,
-    extras_require={
-        ':python_version <= "3.3"': ['pathlib2'],
-    },
     entry_points={
         'console_scripts': [
             'ashlar=ashlar.scripts.ashlar:main',
@@ -125,7 +121,6 @@ setup(
         'License :: OSI Approved :: %s' % LICENSE,
         'Natural Language :: English',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
         'Topic :: Scientific/Engineering :: Visualization'
     ],


### PR DESCRIPTION
* Remove compatibility imports and deprecation warning
* Update dependency versions (including some py3-only releases)
* Update Dockerfile to run with Python 3 instead of 2