### PR TITLE
Fix support for terminal colors on Windows

### DIFF
--- a/ashlar/scripts/ashlar.py
+++ b/ashlar/scripts/ashlar.py
@@ -3,8 +3,7 @@ import sys
 import re
 import argparse
 import pathlib
-import colorama
-import blessings
+import blessed
 from .. import __version__ as VERSION
 from .. import reg
 from ..reg import PlateReader, BioformatsReader
@@ -343,8 +342,7 @@ def parse_kwargs_string(string):
 
 def configure_terminal():
     global terminal
-    colorama.init()
-    terminal = blessings.Terminal()
+    terminal = blessed.Terminal()
 
 
 def print_error(message):

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,7 @@ requires = [
     'scipy>=1.3,<1.4', # Until pyfftw updated for scipy 1.4 fft API change
     'scikit-image>=0.16.2',
     'scikit-learn>=0.21.1',
-    'blessings>=1.7',
-    'colorama>=0.4.3',
+    'blessed>=1.17',
 ]
 
 


### PR DESCRIPTION
Switch from blessings, which does not support Windows (even though its
documentation claimed otherwise), to blessed, a fork which does.