### PR TITLE
Improve preview_slide performance and add log scaling

### DIFF
--- a/ashlar/utils.py
+++ b/ashlar/utils.py
@@ -141,11 +141,13 @@ def paste(target, img, pos, func=None):
         xi = 0
     target_slice = target[yi:yi+img.shape[0], xi:xi+img.shape[1]]
     img = crop_like(img, target_slice)
-    if img.ndim == 2:
-        img = scipy.ndimage.shift(img, pos_f)
-    else:
-        for c in range(img.shape[2]):
-            img[...,c] = scipy.ndimage.shift(img[...,c], pos_f)
+    # Skip expensive sub-pixel shift if fractional position is zero.
+    if pos_f.any():
+        if img.ndim == 2:
+            img = scipy.ndimage.shift(img, pos_f)
+        else:
+            for c in range(img.shape[2]):
+                img[...,c] = scipy.ndimage.shift(img[...,c], pos_f)
     # For any axis where there is a non-zero subpixel shift, crop out the last
     # row or column of pixels on the "losing" side. These pixels will be darker
     # than normal and will introduce artifacts in most blending modes.


### PR DESCRIPTION
* Stop using subpixel precision when compositing, for performance.
* Add -l argument to log-scale pixel intensities. This is useful when
  images contain a few bright spots which throws off matplotlib's automatic
  dynamic range adjustment. For the rough previews this tool is designed
  for, this option should possibly be on by default.