### PR TITLE
Fix warning formatter function signature

### DIFF
--- a/ashlar/scripts/ashlar.py
+++ b/ashlar/scripts/ashlar.py
@@ -349,11 +349,11 @@ def print_error(message):
     print(terminal.bright_red("ERROR:"), message)
 
 
-def warning_formatter(message, category, filename, lineno, file=None, line=None):
+def warning_formatter(message, category, filename, lineno, line=None):
     if issubclass(category, reg.DataWarning):
         return terminal.bright_yellow("WARNING:") + f" {message}\n"
     else:
-        return _old_formatwarning(message, category, filename, lineno, file, line)
+        return _old_formatwarning(message, category, filename, lineno, line)
 
 
 def configure_warning_format():


### PR DESCRIPTION
I worked from some example code at https://pymotw.com/2/warnings/ but
didn't test it with regular warnings (the ones we don't specially
format ourselves). I should have double-checked the actual signature
of warnings.formatwarning myself.