### PR TITLE
Make non-bioformats readers tolerant of multi-plane images

### DIFF
--- a/ashlar/filepattern.py
+++ b/ashlar/filepattern.py
@@ -110,6 +110,10 @@ class FilePatternReader(reg.Reader):
         kwargs = {}
         if self.metadata.multi_channel_tiles:
             kwargs['key'] = c
+        else:
+            # In case of multi-plane images, only take the first plane. The
+            # processing code only handles 2D image arrays!
+            kwargs['key'] = 0
         return skimage.io.imread(path, **kwargs)
 
     def filename(self, series, c):

--- a/ashlar/fileseries.py
+++ b/ashlar/fileseries.py
@@ -166,4 +166,8 @@ class FileSeriesReader(reg.PlateReader):
         kwargs = {}
         if self.metadata.multi_channel_tiles:
             kwargs['key'] = c
+        else:
+            # In case of multi-plane images, only take the first plane. The
+            # processing code only handles 2D image arrays!
+            kwargs['key'] = 0
         return skimage.io.imread(path, **kwargs)

--- a/ashlar/zen.py
+++ b/ashlar/zen.py
@@ -83,5 +83,5 @@ class ZenReader(reg.Reader):
 
     def read(self, series, c):
         path = self.metadata.image_path(series, c)
-        img = skimage.io.imread(str(path))
+        img = skimage.io.imread(str(path), key=0)
         return img


### PR DESCRIPTION
Previously, the readers using skimage.io.imread would return a 3D image array
when passed multi-plane image files, even if they only expected 2D images. These
3D images caused various problems when they "escaped" into the image handling
parts of the code. This change updates these readers to be more defensive and
explicitly read only the first image plane.