### PR TITLE
Fix aligning multiple single-tile cycles

### DIFF
--- a/ashlar/reg.py
+++ b/ashlar/reg.py
@@ -618,6 +618,9 @@ class EdgeAligner(object):
         cc0 = list(components[0])
         self.lr = sklearn.linear_model.LinearRegression()
         self.lr.fit(self.metadata.positions[cc0], self.positions[cc0])
+        # Fix up degenerate transform matrix (e.g. when we have only one tile).
+        if (self.lr.coef_ == 0).all():
+            self.lr.coef_ = np.diag(np.ones(2))
         # Adjust position of remaining components so their centroids match
         # the predictions of the model.
         for cc in components[1:]:


### PR DESCRIPTION
With one tile, the EdgeAligner linear model ended up with a transform
matrix of all zeros, which led the LayerAligner to make incorrect
predictions about the expected location of the tiles in the later cycles
and thus reject them too often. In this change we detect the degenerate
transform and reset it to the identity matrix.