### PR TITLE
Fix defect in mosaic tile blending logic

### DIFF
--- a/ashlar/utils.py
+++ b/ashlar/utils.py
@@ -3,6 +3,7 @@ import warnings
 import skimage.feature
 import skimage.io
 import skimage.restoration.uft
+import skimage.morphology
 import skimage.util
 import skimage.util.dtype
 import scipy.ndimage
@@ -166,8 +167,12 @@ def paste(target, img, pos, func=None):
 
 
 def pastefunc_blend(target, img):
-    # Linear blend based on distance to unfilled space in target.
-    dist = scipy.ndimage.distance_transform_cdt(target)
+    """Linear blend based on distance to unfilled space in target."""
+    # This should catch actual holes but not the actual unfilled space.
+    # FIXME Should generate mask from tile boundaries instead.
+    hole_threshold = np.mean(target.shape)
+    mask = skimage.morphology.remove_small_holes(target != 0, hole_threshold)
+    dist = scipy.ndimage.distance_transform_cdt(mask)
     dmax = dist.max()
     if dmax == 0:
         alpha = 0


### PR DESCRIPTION
The tile blending uses an alpha mask computed from the distance transform, but
was not taking into account the possibility of zero-valued pixels in the actual
images. A morphological hole-removal step was added to fix this problem.
Ultimately this should be addressed by using the known tile bounds to
initialize the mask for the distance transform, but that will require some
refactoring.