### PR TITLE
Rescale edge-aligner to enable registering images of different scales

### DIFF
--- a/ashlar/thumbnail.py
+++ b/ashlar/thumbnail.py
@@ -42,7 +42,8 @@ def calculate_cycle_offset(reader1, reader2, scale=0.05):
     img2 = reader2.thumbnail
     if img1.shape != img2.shape:
         padded_shape = np.array((img1.shape, img2.shape)).max(axis=0)
-        padded_img1, padded_img2 = np.zeros(padded_shape), np.zeros(padded_shape)
+        padded_img1 = np.zeros(padded_shape, dtype=img1.dtype)
+        padded_img2 = np.zeros(padded_shape, dtype=img2.dtype)
         utils.paste(padded_img1, img1, [0, 0])
         utils.paste(padded_img2, img2, [0, 0])
         img1 = padded_img1

--- a/ashlar/utils.py
+++ b/ashlar/utils.py
@@ -212,3 +212,9 @@ def imsave(fname, arr, **kwargs):
     del kwargs["check_contrast"]
     import skimage.external.tifffile
     skimage.external.tifffile.imsave(fname, arr, **kwargs)
+
+
+def scale_shape(shape, scale):
+    scaled_shape = np.array(shape).astype(np.float64)
+    scaled_shape *= scale
+    return tuple(scaled_shape.astype(np.int64))


### PR DESCRIPTION
Add an optional --scale argument in the CLI to allow user specify relative resolution scales for each cycle. Current implementation only downscale images and add fixed filename prefixes when there are multiple scales.