### PR TITLE
Fix parsing of channel in filenames

### DIFF
--- a/ashlar/filepattern.py
+++ b/ashlar/filepattern.py
@@ -118,5 +118,5 @@ class FilePatternReader(reg.Reader):
 
     def filename(self, series, c):
         row, col = self.metadata.tile_rc(series)
+        c = self.metadata.channel_map[c]
         return self.pattern.format(row=row, col=col, channel=c)
-


### PR DESCRIPTION
The filepattern reader now correctly uses the set of channel strings
parsed from the filenames rather than their 0-based indexes. This fixes
the reader when channels are numbers that don't start at 0 or arbitrary
strings.