### PR TITLE
Use old normalization method (none) for phase cross correlation

### DIFF
--- a/ashlar/thumbnail.py
+++ b/ashlar/thumbnail.py
@@ -31,7 +31,11 @@ def calculate_image_offset(img1, img2, upsample_factor=1):
     ref = utils.whiten(img1, 0)
     test = utils.whiten(img2, 0)
     shift = phase_cross_correlation(
-        ref, test, upsample_factor=upsample_factor, return_error=False
+        ref,
+        test,
+        upsample_factor=upsample_factor,
+        normalization=None,
+        return_error=False,
     )
     return shift
 

--- a/ashlar/utils.py
+++ b/ashlar/utils.py
@@ -21,7 +21,11 @@ def register(img1, img2, sigma, upsample=10):
     img1w = whiten(img1, sigma)
     img2w = whiten(img2, sigma)
     shift = skimage.registration.phase_cross_correlation(
-        img1w, img2w, upsample_factor=upsample, return_error=False
+        img1w,
+        img2w,
+        upsample_factor=upsample,
+        normalization=None,
+        return_error=False,
     )
     # At this point we may have a shift in the wrong quadrant since the FFT
     # assumes the signal is periodic. We test all four possibilities and return


### PR DESCRIPTION
When skimage switched to `register.phase_cross_correlation` it also changed the default normalization method. We need the old method (none) for correct behavior.