### PR TITLE
Fix regressions in plates (HTS) mode

### DIFF
--- a/ashlar/reg.py
+++ b/ashlar/reg.py
@@ -261,20 +261,19 @@ class BioformatsMetadata(PlateMetadata):
 
     @property
     def plate_well_series(self):
-        if hasattr(self, '_plate_well_series'):
-            return self._plate_well_series
-        # FIXME Store slice objects to save resources where possible.
-        series = [
-            [
-                np.array([
-                    self._metadata.getWellSampleIndex(p, w, s).value
-                    for s in range(self._metadata.getWellSampleCount(p, w))
-                ], dtype=int)
-                for w in range(num_wells)
+        if not hasattr(self, '_plate_well_series'):
+            # FIXME Store slice objects to save resources where possible.
+            self._plate_well_series = [
+                [
+                    [
+                        self._metadata.getWellSampleIndex(p, w, s).value
+                        for s in range(self._metadata.getWellSampleCount(p, w))
+                    ]
+                    for w in range(num_wells)
+                ]
+                for p, num_wells in enumerate(self.num_wells)
             ]
-            for p, num_wells in enumerate(self.num_wells)
-        ]
-        return series
+        return self._plate_well_series
 
     @property
     def pixel_size(self):

--- a/ashlar/scripts/ashlar.py
+++ b/ashlar/scripts/ashlar.py
@@ -296,9 +296,13 @@ def process_plates(
         for w, well_name in enumerate(metadata.well_names[p]):
             print("Well {}\n-----".format(well_name))
             if len(metadata.plate_well_series[p][w]) > 0:
-                well_path = output_path / plate_name / well_name
-                well_path.mkdir(parents=True, exist_ok=True)
-                mosaic_path_format = str(well_path / filename_format)
+                plate_path = output_path / plate_name
+                if pyramid:
+                    out_file_path = plate_path / f"{well_name}_{filename_format}"
+                else:
+                    out_file_path = plate_path / well_name / filename_format
+                out_file_path.parent.mkdir(parents=True, exist_ok=True)
+                mosaic_path_format = str(out_file_path)
                 process_single(
                     filepaths, mosaic_path_format, flip_x, flip_y,
                     ffp_paths, dfp_paths, aligner_args, mosaic_args, pyramid,


### PR DESCRIPTION
* Store image series indexes as lists of Python ints instead of numpy arrays
  as pyjnius doesn't seem to detect and cast numpy.int64 like it used to.
* Improve the output filename generation to avoid creating the last level
  of directories per well if not needed (i.e. with OME-TIFF output).