### PR TITLE
Use zlib compression in ome-tiff output

### DIFF
--- a/ashlar/reg.py
+++ b/ashlar/reg.py
@@ -1236,6 +1236,7 @@ class PyramidWriter:
                 resolution=(resolution_cm, resolution_cm, "centimeter"),
                 # FIXME Propagate this from input files (especially RGB).
                 photometric="minisblack",
+                compression="adobe_deflate",
             )
             if self.verbose:
                 print("Generating pyramid")
@@ -1250,6 +1251,7 @@ class PyramidWriter:
                     subfiletype=1,
                     dtype=dtype,
                     tile=tile_shape,
+                    compression="adobe_deflate",
                 )
                 if self.verbose:
                     print()


### PR DESCRIPTION
We should also enable the predictor but there is a bug in tifffile (#185)