### PR TITLE
Add barrel/pincushion correction support

### DIFF
--- a/ashlar/reg.py
+++ b/ashlar/reg.py
@@ -423,7 +423,7 @@ class BarrelCorrectionReader(Reader):
     def read(self, series, c):
         img = self.reader.read(series, c)
         img = transform.barrel_correction(img, self.k)
-        img = skimage.util.img_as_uint(img)
+        img = utils.dtype_convert(img, self.metadata.pixel_dtype)
         return img
 
 

--- a/ashlar/reg.py
+++ b/ashlar/reg.py
@@ -22,6 +22,7 @@ import matplotlib.patheffects as mpatheffects
 import zarr
 from . import utils
 from . import thumbnail
+from . import transform
 from . import __version__ as _version
 
 
@@ -405,6 +406,24 @@ class BioformatsReader(PlateReader):
         dtype = self.metadata.pixel_dtype
         shape = self.metadata.tile_size(series)
         img = np.frombuffer(byte_array.tostring(), dtype=dtype).reshape(shape)
+        return img
+
+
+class BarrelCorrectionReader(Reader):
+    """Wraps a reader to correct barrel/pincushion image distortion."""
+
+    def __init__(self, reader, k):
+        self.reader = reader
+        self.k = k
+
+    @property
+    def metadata(self):
+        return self.reader.metadata
+
+    def read(self, series, c):
+        img = self.reader.read(series, c)
+        img = transform.barrel_correction(img, self.k)
+        img = skimage.util.img_as_uint(img)
         return img
 
 

--- a/ashlar/transform.py
+++ b/ashlar/transform.py
@@ -7,7 +7,11 @@ def _barrel_mapping(xy, center, k):
     y0, x0 = center
     x -= x0
     y -= y0
-    f = 1 + k  * (x ** 2 + y ** 2)
+    # The warp mapping function defines the INVERSE map to apply, which in the
+    # case of a distortion correction is the FORWARD map of the distortion
+    # itself. See Fitzgibbon 2001 eq 1 for details.
+    r2 = x ** 2 + y ** 2
+    f = 1 + k * r2
     xy[..., 0] = x * f + x0
     xy[..., 1] = y * f + y0
     return xy
@@ -24,6 +28,59 @@ def barrel_correction(
     clip=True,
     preserve_range=False,
 ):
+    """Perform a transform to correct for barrel or pincushion distortion.
+
+    Parameters
+    ----------
+    image : ndarray
+        Input image.
+    k : float
+        Distortion parameter
+    center : (row, column) tuple or (2,) ndarray, optional
+        Center coordinate of transformation.
+
+    Returns
+    -------
+    cartesian : ndarray
+        Cartesian version of the input.
+        Rows correspond to radius and columns to angle values.
+
+    Other parameters
+    ----------------
+    output_shape : tuple (rows, cols), optional
+        Shape of the output image generated. By default the shape of the input
+        image is preserved.
+    order : int, optional
+        The order of the spline interpolation, default is 1. The order has to
+        be in the range 0-5. See `skimage.transform.warp` for detail.
+    mode : {'constant', 'edge', 'symmetric', 'reflect', 'wrap'}, optional
+        Points outside the boundaries of the input are filled according
+        to the given mode, with 'constant' used as the default. Modes match
+        the behaviour of `numpy.pad`.
+    cval : float, optional
+        Used in conjunction with mode 'constant', the value outside
+        the image boundaries.
+    clip : bool, optional
+        Whether to clip the output to the range of values of the input image.
+        This is enabled by default, since higher order interpolation may
+        produce values outside the given input range.
+    preserve_range : bool, optional
+        Whether to keep the original range of values. Otherwise, the input
+        image is converted according to the conventions of `img_as_float`.
+
+    Notes
+    -----
+    Radial distortion is modeled here using a one-parameter model described in
+    [1]_ (Equation 1).
+
+    References
+    ----------
+    .. [1] A. W. Fitzgibbon, "Simultaneous linear estimation of multiple view
+       geometry and lens distortion," Proceedings of the 2001 IEEE Computer
+       Society Conference on Computer Vision and Pattern Recognition. CVPR 2001,
+       Kauai, HI, USA, 2001, pp. I-I. :DOI:`10.1109/CVPR.2001.990465`.
+
+    """
 
     if mode is None:
         mode = "constant"

--- a/ashlar/transform.py
+++ b/ashlar/transform.py
@@ -1,0 +1,38 @@
+import numpy as np
+from skimage.transform import warp
+
+
+def _barrel_mapping(xy, center, k):
+    x, y = xy.T.astype(float)
+    y0, x0 = center
+    x -= x0
+    y -= y0
+    f = 1 + k  * (x ** 2 + y ** 2)
+    xy[..., 0] = x * f + x0
+    xy[..., 1] = y * f + y0
+    return xy
+
+
+def barrel_correction(
+    image,
+    k,
+    center=None,
+    output_shape=None,
+    order=1,
+    mode=None,
+    cval=0,
+    clip=True,
+    preserve_range=False,
+):
+
+    if mode is None:
+        mode = "constant"
+
+    if center is None:
+        center = np.array(image.shape)[:2] / 2
+
+    warp_args = {"center": center, "k": k}
+
+    return warp(image, _barrel_mapping, map_args=warp_args,
+                output_shape=output_shape, order=order, mode=mode, cval=cval,
+                clip=clip, preserve_range=preserve_range)

--- a/ashlar/utils.py
+++ b/ashlar/utils.py
@@ -157,10 +157,7 @@ def paste(target, img, pos, func=None):
             return
     if np.issubdtype(img.dtype, np.floating):
         np.clip(img, 0, 1, img)
-    # It's safe to silence this FutureWarning as we pinned the skimage version.
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", r".*scikit-image 1\.0", FutureWarning)
-        img = skimage.util.dtype.convert(img, target.dtype)
+    img = dtype_convert(img, target.dtype)
     if func is None:
         target_slice[:] = img
     elif isinstance(func, np.ufunc):
@@ -190,6 +187,19 @@ def crop_like(img, target):
     if (img.shape[1] > target.shape[1]):
         img = img[:, :target.shape[1]]
     return img
+
+
+def dtype_convert(img, dtype):
+    """Convert an image to the requested data-type.
+
+    This is just a wrapper around skimage.util.dtype.convert that silences its
+    FutureWarning, as Ashlar pins skimage to a version before that planned
+    deprecation.
+
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", r".*scikit-image 1\.0", FutureWarning)
+        return skimage.util.dtype.convert(img, dtype)
 
 
 def imsave(fname, arr, **kwargs):


### PR DESCRIPTION
This adds a `--barrel-correction` argument that takes a single floating point value which is used in a simple one-parameter image warping model to correct for barrel/pincushion distortion. The parameter is deliberately undocumented as the process for choosing its value is not yet well defined.