### PR TITLE
Escape parentheses in fileseries/filepattern pattern

### DIFF
--- a/ashlar/filepattern.py
+++ b/ashlar/filepattern.py
@@ -31,8 +31,10 @@ class FilePatternMetadata(reg.Metadata):
     def _enumerate_tiles(self):
         # Translate a restricted subset of the "format" pattern language to
         # a matching regex with named capture.
-        regex = re.sub(r'{([^:}]+)(?:[^}]*)}', r'(?P<\1>.*?)',
-                       self.pattern.replace('.', '\.'))
+        pattern = self.pattern.replace('.', '\.')
+        pattern = pattern.replace('(', '\(')
+        pattern = pattern.replace(')', '\)')
+        regex = re.sub(r'{([^:}]+)(?:[^}]*)}', r'(?P<\1>.*?)', pattern)
         rows = set()
         cols = set()
         channels = set()

--- a/ashlar/fileseries.py
+++ b/ashlar/fileseries.py
@@ -17,6 +17,8 @@ def format_to_regex(s):
     # Translate a restricted subset of the "format" pattern language to
     # a matching regex with named capture.
     s = s.replace('.', '\.')
+    s = s.replace('(', '\(')
+    s = s.replace(')', '\)')
     regex = re.sub(r'{([^:}]+):?([^}]*)}', f2r_repl, s)
     return regex
 


### PR DESCRIPTION
This allows literal parentheses in filenames to be matched.