### PR TITLE
Add the option to choose alignment channel by name

### DIFF
--- a/ashlar/filepattern.py
+++ b/ashlar/filepattern.py
@@ -98,6 +98,13 @@ class FilePatternMetadata(reg.Metadata):
         row = i // self.width + self.row_offset
         col = i % self.width + self.col_offset
         return row, col
+    
+    def get_from_channel_map(self, c):
+        if isinstance(c, int):
+            return self.channel_map[c]
+        if c in list(self.channel_map.values()):
+            return c
+        raise Exception(f"{c} was notrecognized as a channel")
 
 
 class FilePatternReader(reg.Reader):
@@ -119,5 +126,5 @@ class FilePatternReader(reg.Reader):
 
     def filename(self, series, c):
         row, col = self.metadata.tile_rc(series)
-        c = self.metadata.channel_map[c]
+        c = self.metadata.get_from_channel_map(c)
         return self.pattern.format(row=row, col=col, channel=c)

--- a/ashlar/fileseries.py
+++ b/ashlar/fileseries.py
@@ -186,10 +186,17 @@ class FileSeriesMetadata(reg.PlateMetadata):
             if self.layout == "snake" and col % 2 == 1:
                 row = self.height - 1 - row
         return row, col
+    
+    def get_from_channel_map(self, c):
+        if isinstance(c, int):
+            return self.channel_map[c]
+        if c in list(self.channel_map.values()):
+            return c
+        raise Exception(f"{c} was notrecognized as a channel")
 
     def filename(self, series, c):
         well, series = self.all_series[self.active_series[series]]
-        c = self.channel_map[c]
+        c = self.get_from_channel_map(c)
         components = self.filename_components[well, series, c]
         return self.pattern.format(**components)
 

--- a/ashlar/scripts/ashlar.py
+++ b/ashlar/scripts/ashlar.py
@@ -33,10 +33,11 @@ def main(argv=sys.argv):
               " exist."),
     )
     parser.add_argument(
-        '-c', '--align-channel', dest='align_channel', type=int,
+        '-c', '--align-channel', dest='align_channel',
         default='0', metavar='CHANNEL',
         help=('Reference channel number for image alignment. Numbering starts'
-              ' at 0.'),
+              ' at 0. If fileseries or filepattern is used, it may be channel'
+              ' name.'),
     )
     parser.add_argument(
         '--flip-x', default=False, action='store_true',


### PR DESCRIPTION
While using fileseries I encountered two problems while working with raw files from MACSims:

1. Not all cycles have the same number of channels
2. Order of channels was sorted while building the metadata

This made it impossible for me to select a channel for reference just by stating the number. For the first cycle it was the first channel, but for the other cycles it was the last one.

My workaround was to allow passing a string with the channel name. Metadata will then check if align channel is a string, and then check if it's inside channel_map values or not (raise Exception). If it's an int, it will use it as key of the dictionary. If it's not, then it will raise Exception.

I took the liberty of adding this to FilePatternMetadata as well.

What do you think?