### PR TITLE
GitHub Actions updates (fixed CI version; added ARM architecture build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Build the Docker container
         run: docker build -t ashlar:test .
 
       # Cache test data to avoid repeated download
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: cache-data
         with:
           path: |
@@ -56,7 +56,7 @@ jobs:
 
       # If the action is successful, the output will be available as a downloadable artifact
       - name: Upload processed result
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: exemplar-001
           path: |

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -1,0 +1,42 @@
+name: dockerhub
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  docker:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux/amd64
+            tag: ${{ github.event.release.tag_name }}
+          - os: ubuntu-24.04-arm
+            platform: linux/arm64
+            tag: ${{ github.event.release.tag_name }}-arm
+    runs-on: ${{ matrix.os }}
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.MCMICRO_USERNAME }}
+          password: ${{ secrets.MCMICRO_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: labsyspharm/ashlar:${{ matrix.tag }}
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
* Updated versions of CI actions to address GitHub deprecation guidelines. The test will actually run now (but fail for [another reason](https://github.com/ArtemSokolov/ashlar/actions/runs/13404471525/job/37441762440)).
* Added a new GitHub Action to build parallel container images for x86 and ARM architectures. Each build job is allocated to its own native runner.

See working examples for other MCMICRO modules:
* https://hub.docker.com/r/labsyspharm/unetcoreograph/tags
* https://hub.docker.com/r/labsyspharm/unmicst/tags

**(It is recommend to disable the Dockerhub-side build trigger prior to merging this PR, as it may result in a conflict with `dockerhub.yml` and potentially undefined behavior.)**
