### PR TITLE
Restrict zarr and tifffile versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ conda activate ashlar
 
 In the activated environment, install dependencies and ashlar itself:
 ```bash
-conda install -y -c conda-forge numpy scipy matplotlib networkx scikit-image scikit-learn tifffile "zarr<3" pyjnius blessed
+conda install -y -c conda-forge numpy scipy matplotlib networkx scikit-image scikit-learn "tifffile<2025.2.18" "zarr<3" pyjnius blessed
 pip install ashlar
 ```
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ conda activate ashlar
 
 In the activated environment, install dependencies and ashlar itself:
 ```bash
-conda install -y -c conda-forge numpy scipy matplotlib networkx scikit-image scikit-learn tifffile zarr pyjnius blessed
+conda install -y -c conda-forge numpy scipy matplotlib networkx scikit-image scikit-learn tifffile "zarr<3" pyjnius blessed
 pip install ashlar
 ```
 

--- a/docs/instructions/installation.md
+++ b/docs/instructions/installation.md
@@ -34,7 +34,7 @@ conda activate ashlar
 
 In the activated environment, install dependencies and ashlar itself:
 ```bash
-conda install -y -c conda-forge numpy scipy matplotlib networkx scikit-image scikit-learn tifffile "zarr<3" pyjnius blessed
+conda install -y -c conda-forge numpy scipy matplotlib networkx scikit-image scikit-learn "tifffile<2025.2.18" "zarr<3" pyjnius blessed
 pip install ashlar
 ```
 

--- a/docs/instructions/installation.md
+++ b/docs/instructions/installation.md
@@ -34,7 +34,7 @@ conda activate ashlar
 
 In the activated environment, install dependencies and ashlar itself:
 ```bash
-conda install -y -c conda-forge numpy scipy matplotlib networkx scikit-image scikit-learn tifffile zarr pyjnius blessed
+conda install -y -c conda-forge numpy scipy matplotlib networkx scikit-image scikit-learn tifffile "zarr<3" pyjnius blessed
 pip install ashlar
 ```
 


### PR DESCRIPTION
Tifffile's zarr integration doesn't support zarr 3, and we are using a tifffile feature that's been discontinued in the latest version. This changes restricts those packages' versions to compatible ones.